### PR TITLE
feat: agregar .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignorar archivos .log en la raíz y cualquier carpeta
+*.log
+**/*.log


### PR DESCRIPTION
se excluyen los archivos .lo del directorio raíz y tambien de todos los subdirectorios.
Los archivos log no deben subirse a un repo y menos público!
*.log - ignora todos los archivos .log en el directorio actual
**/*.log - ignora todos los archivos .log en cualquier subdirectorio